### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "openssl"
+description := "A robust, commercial-grade TLS/SSL and full-strength general purpose cryptographic library."
+gitrepo     := "https://github.com/openssl/openssl.git"
+homepage    := "https://www.openssl.org/"
+version     := 1.1.1c sha256:f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90 https://www.openssl.org/source/old/1.1.1/openssl-1.1.1c.tar.gz
+license     := "Apache-2.0"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

