### PR TITLE
Makefile.uk: Silence warnings

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -90,6 +90,7 @@ LIBSSL_CFLAGS-y      += $(LIBOPENSSL_SUPPRESS_FLAGS) -Wno-pointer-to-int-cast -W
 LIBSSL_CXXFLAGS-y    += $(LIBOPENSSL_SUPPRESS_FLAGS)
 
 LIBCRYPTO_CFLAGS-y   += $(LIBOPENSSL_SUPPRESS_FLAGS) -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+LIBCRYPTO_CFLAGS-$(call have_gcc) += -Wno-maybe-uninitialized
 LIBCRYPTO_CXXFLAGS-y += $(LIBOPENSSL_SUPPRESS_FLAGS)
 
 # Extracted from original build
@@ -106,6 +107,7 @@ LIBSSL_CXXFLAGS-y    += $(LIBOPENSSL_DEFINES)
 
 LIBCRYPTO_CFLAGS-y   += $(LIBOPENSSL_DEFINES)
 LIBCRYPTO_CXXFLAGS-y += $(LIBOPENSSL_DEFINES)
+LIBCRYPTO_ASFLAGS-y += -Wno-unused-command-line-argument
 
 ################################################################################
 # SSL code


### PR DESCRIPTION
This change silences two classes of warnings:
- GCC-specific "maybe uninitialized use" warnings
- Clang assembler complaining about unused CLI args