### PR TITLE
fix(link):fixed old broken link

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -2,5 +2,5 @@ name        := "openssl"
 description := "A robust, commercial-grade TLS/SSL and full-strength general purpose cryptographic library."
 gitrepo     := "https://github.com/openssl/openssl.git"
 homepage    := "https://www.openssl.org/"
-version     := 1.1.1c sha256:f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90 https://www.openssl.org/source/old/1.1.1/openssl-1.1.1c.tar.gz
+version     := 1.1.1c sha256:f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90 https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1c/openssl-1.1.1c.tar.gz
 license     := "Apache-2.0"

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -45,7 +45,7 @@ $(eval $(call addlib_s,libopensslglue,$(CONFIG_LIBOPENSSL)))
 LIBOPENSSL_MAJOR=1.1.1
 LIBOPENSSL_MINOR=c
 LIBOPENSSL_VERSION=$(LIBOPENSSL_MAJOR)$(LIBOPENSSL_MINOR)
-LIBOPENSSL_URL=https://www.openssl.org/source/old/$(LIBOPENSSL_MAJOR)/openssl-$(LIBOPENSSL_VERSION).tar.gz
+LIBOPENSSL_URL=https://github.com/openssl/openssl/releases/download/OpenSSL_$(subst .,_,$(LIBOPENSSL_MAJOR))$(LIBOPENSSL_MINOR)/openssl-$(LIBOPENSSL_VERSION).tar.gz
 LIBOPENSSL_PATCHDIR=$(LIBSSL_BASE)/patches
 LIBOPENSSL_SUBDIR=openssl-$(LIBOPENSSL_VERSION)
 $(eval $(call fetch,libssl,$(LIBOPENSSL_URL)))


### PR DESCRIPTION
The older openssl.org/source/old link does not works now so replaced it with github/releases one.